### PR TITLE
po: update POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,10 +1,8 @@
 
 
 # List of source files containing translatable strings.
-capplet/data/dawati-applications-panel-properties.desktop.in
 capplet/data/dawati-toolbar-properties.desktop.in
 capplet/data/system-tray-properties.desktop.in
-capplet/src/app-cc-panel.c
 capplet/src/dawati-toolbar-properties.c
 capplet/src/mtp-toolbar.c
 capplet/src/mtp-bin.c
@@ -44,11 +42,6 @@ panels/bluetooth/src/dawati-bt-shell.c
 panels/bluetooth/src/dawati-panel-bt.c
 
 panels/datetime/data/dawati-panel-datetime.desktop.in.in
-panels/datetime/src/dawati-alarm-notify.c
-panels/datetime/src/mnp-alarm-dialog.c
-panels/datetime/src/mnp-alarm-instance.c
-panels/datetime/src/mnp-alarm-tile.c
-panels/datetime/src/mnp-alarms.c
 panels/datetime/src/mnp-clock-area.c
 panels/datetime/src/mnp-utils.c
 panels/datetime/src/dawati-panel-date-time.c


### PR DESCRIPTION
There are several source files listed in POTFILES.in that are not part
of the dawati-shell dist tarball, so remove them.

This fixes running `intltool-update --pot` inside the dist tarball.
