### PR TITLE
capplet: move two undistributed files to POTFILES.skip

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,10 +1,8 @@
 
 
 # List of source files containing translatable strings.
-capplet/data/dawati-applications-panel-properties.desktop.in
 capplet/data/dawati-toolbar-properties.desktop.in
 capplet/data/system-tray-properties.desktop.in
-capplet/src/app-cc-panel.c
 capplet/src/dawati-toolbar-properties.c
 capplet/src/mtp-toolbar.c
 capplet/src/mtp-bin.c

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,3 +1,5 @@
+capplet/data/dawati-applications-panel-properties.desktop.in
+capplet/src/app-cc-panel.c
 panels/datetime/src/dawati-alarm-notify.c
 panels/datetime/src/mnp-alarm-dialog.c
 panels/datetime/src/mnp-alarm-instance.c


### PR DESCRIPTION
Hi,

I see that several files from POTFILES.in that were breaking `intltool-update --pot` in po/ were recently moved to POTFILES.skip.  I didn't consider this option when sending my original pull request to fix POT generation, but I like that solution better.

This commit moves two more files from POTFILES.in to POTFILES.skip to "unbreak" POT generation in the dist tarballs.  I've haven't run a distcheck, but I assume that this won't break anything.

Thanks,
Patrick
